### PR TITLE
Support cancellations

### DIFF
--- a/lib/tickeos_b2b/api/cancel.rb
+++ b/lib/tickeos_b2b/api/cancel.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module TickeosB2b
+  module Api
+    class Cancel
+      def self.request_body(server_order_product_serial, go = 1)
+        Nokogiri::XML::Builder.new do |xml|
+          xml.TICKeosProxy(apiVersion: '', version: '', instanceName: '') do
+            xml.txCancelRequest(
+              go:                 go,
+              context:            'merchant',
+              orderProductSerial: server_order_product_serial
+            )
+          end
+        end.to_xml
+      end
+
+      def self.request_method
+        :post
+      end
+    end
+  end
+end

--- a/lib/tickeos_b2b/client.rb
+++ b/lib/tickeos_b2b/client.rb
@@ -5,6 +5,7 @@ require 'nokogiri'
 require 'nori'
 require 'uri'
 
+require_relative 'api/cancel'
 require_relative 'api/product_list'
 require_relative 'api/product_data'
 require_relative 'api/purchase'
@@ -62,6 +63,16 @@ module TickeosB2b
       @request_method = Api::Order.request_method
 
       Order.from_json(call)
+    end
+
+    def cancel(ticket_id)
+      @request_body = Api::Cancel.request_body(ticket_id)
+      @request_method = Api::Cancel.request_method
+
+      result = call
+      return :error unless result.dig('TICKeosProxy', 'txCancelResponse', 'error').blank?
+
+      :cancelled
     end
 
     private

--- a/lib/tickeos_b2b/order.rb
+++ b/lib/tickeos_b2b/order.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
-require 'base64'
-
 module TickeosB2b
   class Order
     ATTRIBUTES = [
       :ticket_id,
+      :state,
       :ticket_data,
       :aztec_content
     ].freeze
@@ -25,12 +24,13 @@ module TickeosB2b
     end
 
     def self.from_json(json)
-      json = json['TICKeosProxy']['txOrderResponse']
+      json = json.dig('TICKeosProxy', 'txOrderResponse')
 
       new(
-        ticket_id:     json['ticketData']['ticket_id'],
-        ticket_data:   json['ticketData'],
-        aztec_content: json['aztecContent']
+        ticket_id:     json.dig('ticketData', 'ticket_id'),
+        state:         :valid,
+        ticket_data:   json.dig('ticketData'),
+        aztec_content: json.dig('aztecContent')
       )
     end
   end

--- a/spec/tickeos_b2b/api/cancel_spec.rb
+++ b/spec/tickeos_b2b/api/cancel_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe TickeosB2b::Api::Cancel do
+  subject(:cancel) { described_class }
+
+  let(:request_body) do
+    <<~XML
+      <?xml version=\"1.0\"?>
+      <TICKeosProxy apiVersion=\"\" version=\"\" instanceName=\"\">
+        <txCancelRequest go=\"1\" context=\"merchant\" orderingSerial=\"42\"/>
+      </TICKeosProxy>
+    XML
+  end
+
+  let(:operation) { cancel.request_body(server_ordering_serial) }
+  let(:server_ordering_serial) { '42' }
+
+  describe '#request_body' do
+    it 'returns the correct xml request body' do
+      expect(operation).to eq(request_body)
+    end
+  end
+
+  describe '#request_method' do
+    it 'returns the correct request method' do
+      expect(cancel.request_method).to eq(:post)
+    end
+  end
+end

--- a/spec/tickeos_b2b/order_spec.rb
+++ b/spec/tickeos_b2b/order_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe TickeosB2b::Order do
     let(:expected_attributes) do
       {
         ticket_id:     nil,
+        state:         nil,
         ticket_data:   nil,
         aztec_content: nil
       }
@@ -81,12 +82,14 @@ RSpec.describe TickeosB2b::Order do
     let(:order) { described_class.from_json(order_json) }
     let(:expected_order_response) { order_json }
     let(:ticket_id) { expected_order_response['TICKeosProxy']['txOrderResponse']['ticketData']['ticket_id'] }
+    let(:state) { :valid }
     let(:ticket_data) { expected_order_response['TICKeosProxy']['txOrderResponse']['ticketData'] }
     let(:aztec_content) { expected_order_response['TICKeosProxy']['txOrderResponse']['aztecContent'] }
 
     it 'extracts the information from order hash correctly' do
       order
       expect(order.ticket_id).to eq(ticket_id)
+      expect(order.state).to eq(state)
       expect(order.ticket_data).to eq(ticket_data)
       expect(order.aztec_content).to eq(aztec_content)
     end


### PR DESCRIPTION
This PR adds functionality to cancel an already ordered ticket/product. This does not cancel a complete order just the requested ticket/product.