### PR TITLE
Add rendered_ticket to Order class

### DIFF
--- a/lib/tickeos_b2b/order.rb
+++ b/lib/tickeos_b2b/order.rb
@@ -5,6 +5,7 @@ module TickeosB2b
     ATTRIBUTES = [
       :ticket_id,
       :state,
+      :rendered_ticket,
       :ticket_data,
       :aztec_content
     ].freeze
@@ -27,10 +28,11 @@ module TickeosB2b
       json = json.dig('TICKeosProxy', 'txOrderResponse')
 
       new(
-        ticket_id:     json.dig('ticketData', 'ticket_id'),
-        state:         :valid,
-        ticket_data:   json.dig('ticketData'),
-        aztec_content: json.dig('aztecContent')
+        ticket_id:       json.dig('ticketData', 'ticket_id'),
+        state:           :valid,
+        rendered_ticket: json.dig('renderedTicket'),
+        ticket_data:     json.dig('ticketData'),
+        aztec_content:   json.dig('aztecContent')
       )
     end
   end

--- a/spec/tickeos_b2b/order_spec.rb
+++ b/spec/tickeos_b2b/order_spec.rb
@@ -66,10 +66,11 @@ RSpec.describe TickeosB2b::Order do
   describe '.attributes' do
     let(:expected_attributes) do
       {
-        ticket_id:     nil,
-        state:         nil,
-        ticket_data:   nil,
-        aztec_content: nil
+        ticket_id:       nil,
+        state:           nil,
+        rendered_ticket: nil,
+        ticket_data:     nil,
+        aztec_content:   nil
       }
     end
 
@@ -83,6 +84,7 @@ RSpec.describe TickeosB2b::Order do
     let(:expected_order_response) { order_json }
     let(:ticket_id) { expected_order_response['TICKeosProxy']['txOrderResponse']['ticketData']['ticket_id'] }
     let(:state) { :valid }
+    let(:rendered_ticket) { expected_order_response['TICKeosProxy']['txOrderResponse']['renderedTicket'] }
     let(:ticket_data) { expected_order_response['TICKeosProxy']['txOrderResponse']['ticketData'] }
     let(:aztec_content) { expected_order_response['TICKeosProxy']['txOrderResponse']['aztecContent'] }
 
@@ -90,6 +92,7 @@ RSpec.describe TickeosB2b::Order do
       order
       expect(order.ticket_id).to eq(ticket_id)
       expect(order.state).to eq(state)
+      expect(order.rendered_ticket).to eq(rendered_ticket)
       expect(order.ticket_data).to eq(ticket_data)
       expect(order.aztec_content).to eq(aztec_content)
     end


### PR DESCRIPTION
This PR adds the rendered ticket to the retrieved ticket data in the `Order` class.