### PR TITLE
Introduce test_run feature

### DIFF
--- a/lib/tickeos_b2b/client.rb
+++ b/lib/tickeos_b2b/client.rb
@@ -139,8 +139,8 @@ module TickeosB2b
 
     def connection
       Faraday.new(url: url) do |f|
-        f.options[:open_timeout] = 5
-        f.options[:timeout] = 15
+        f.options[:open_timeout] = 10
+        f.options[:timeout] = 30
         f.request :url_encoded
         f.adapter :net_http
         f.basic_auth(username, password)

--- a/lib/tickeos_b2b/client.rb
+++ b/lib/tickeos_b2b/client.rb
@@ -10,6 +10,11 @@ require_relative 'api/product_list'
 require_relative 'api/product_data'
 require_relative 'api/purchase'
 require_relative 'api/order'
+require_relative 'test_run/default_api_response'
+require_relative 'test_run/order'
+require_relative 'test_run/product_data'
+require_relative 'test_run/product_list'
+require_relative 'test_run/purchase'
 
 module TickeosB2b
   class Client
@@ -17,34 +22,48 @@ module TickeosB2b
                 :username,
                 :password,
                 :request_body,
-                :request_method
+                :request_method,
+                :test_run,
+                :options
 
-    def initialize(url:, username:, password:)
+    def initialize(url:, username:, password:, test_run: false, options: TestRun::DefaultApiResponse.options)
       @url = URI(url)
       @username = username
       @password = password
+      @test_run = test_run
+      @options = options
     end
 
     def product_list
       @request_body = Api::ProductList.request_body
       @request_method = Api::ProductList.request_method
 
-      Product.from_json(response: call)
+      case test_run
+      when true
+        Product.from_json(response: TestRun::ProductList.product_list(options))
+      when false
+        Product.from_json(response: call)
+      end
     end
 
     def load!(product:, full_product_info: false)
       @request_body = Api::ProductData.request_body(reference_id: product.reference_id)
       @request_method = Api::ProductData.request_method
 
-      return call if full_product_info
+      return call if full_product_info & !test_run
 
-      Product.load_product_data(
-        product:  product,
-        response: call
-      )
-    end
-
-    def validate
+      case test_run
+      when true
+        Product.load_product_data(
+          product:  product,
+          response: TestRun::ProductData.load!(options, product.reference_id)
+        )
+      when false
+        Product.load_product_data(
+          product:  product,
+          response: call
+        )
+      end
     end
 
     def purchase(product:, personalisation_data:, dry_run: false)
@@ -58,7 +77,18 @@ module TickeosB2b
       @request_body = Api::Purchase.request_body(pre_check: pre_check, go: go, ticket: ticket)
       @request_method = Api::Purchase.request_method
 
-      Ticket.load_ticket_data(ticket: ticket, response: call)
+      case test_run
+      when true
+        Ticket.load_ticket_data(
+          ticket:   ticket,
+          response: TestRun::Purchase.purchase(options, product.reference_id)
+        )
+      when false
+        Ticket.load_ticket_data(
+          ticket:   ticket,
+          response: call
+        )
+      end
     end
 
     def order(ticket:)
@@ -70,7 +100,12 @@ module TickeosB2b
       )
       @request_method = Api::Order.request_method
 
-      Order.from_json(response: call)
+      case test_run
+      when true
+        Order.from_json(response: TestRun::Order.order(options, ticket.product.reference_id))
+      when false
+        Order.from_json(response: call)
+      end
     end
 
     def cancel(ticket_id:)

--- a/lib/tickeos_b2b/test_run/default_api_response.rb
+++ b/lib/tickeos_b2b/test_run/default_api_response.rb
@@ -33,7 +33,6 @@ module TickeosB2b
               sale_date_to:               '',
               distribution_method:        'mobile',
               visible:                    '1'
-
             },
             ST_Child: {
               id:                         '02',

--- a/lib/tickeos_b2b/test_run/default_api_response.rb
+++ b/lib/tickeos_b2b/test_run/default_api_response.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'base64'
+
+module TickeosB2b
+  module TestRun
+    class DefaultApiResponse
+      def self.options
+        {
+          product_list: [
+            {
+              name:         'Single ticket - Adult',
+              reference_id: 'ST_Adult'
+            },
+            {
+              name:         'Single ticket - Child',
+              reference_id: 'ST_Child'
+            },
+            {
+              name:         'Group ticket',
+              reference_id: 'GT'
+            }
+          ],
+          product_data: {
+            ST_Adult: {
+              id:                         '01',
+              vu_name:                    'vu_name',
+              vu_role:                    'role',
+              sort_order:                 '1',
+              tariff_zone_count:          '0',
+              tariff_zone_count_required: '0',
+              sale_date_from:             '',
+              sale_date_to:               '',
+              distribution_method:        'mobile',
+              visible:                    '1'
+
+            },
+            ST_Child: {
+              id:                         '02',
+              vu_name:                    'vu_name',
+              vu_role:                    'role',
+              sort_order:                 '2',
+              tariff_zone_count:          '0',
+              tariff_zone_count_required: '0',
+              sale_date_from:             '',
+              sale_date_to:               '',
+              distribution_method:        'mobile',
+              visible:                    '1'
+            },
+            GT:       {
+              id:                         '03',
+              vu_name:                    'vu_name',
+              vu_role:                    'role',
+              sort_order:                 '3',
+              tariff_zone_count:          '0',
+              tariff_zone_count_required: '0',
+              sale_date_from:             '',
+              sale_date_to:               '',
+              distribution_method:        'mobile',
+              visible:                    '1'
+            }
+          },
+          purchase:     {
+            ST_Adult: {
+              server_ordering_serial:      '2012112900001',
+              server_order_product_serial: '1211599',
+              price_net:                   '3.25',
+              price_gross:                 '3.5',
+              price_vat:                   '0.25',
+              price_vat_rate:              '7'
+            },
+            ST_Child: {
+              server_ordering_serial:      '2012112900002',
+              server_order_product_serial: '1211600',
+              price_net:                   '3.25',
+              price_gross:                 '3.5',
+              price_vat:                   '0.25',
+              price_vat_rate:              '7'
+            },
+            GT:       {
+              server_ordering_serial:      '2012112900003',
+              server_order_product_serial: '1211601',
+              price_net:                   '6.51',
+              price_gross:                 '7',
+              price_vat:                   '0.49',
+              price_vat_rate:              '7'
+            }
+          },
+          order:        {
+            ST_Adult: {
+              rendered_ticket: Base64.encode64("https://xkcd.com/#{rand(1..2000)}/"),
+              ticket_data:     {
+                ticket_id:    '800001',
+                ticket_type:  'Ticket',
+                product_name: 'Single Ticket',
+                price:        '5.0',
+                vat_rate:     '7',
+                currency:     'EUR'
+              },
+              aztec_content:   Base64.encode64("https://xkcd.com/#{rand(1..2000)}/")
+            },
+            ST_Child: {
+              rendered_ticket: Base64.encode64("https://xkcd.com/#{rand(1..2000)}/"),
+              ticket_data:     {
+                ticket_id:    '800002',
+                ticket_type:  'Ticket',
+                product_name: 'Single Ticket',
+                price:        '3.5',
+                vat_rate:     '7',
+                currency:     'EUR'
+              },
+              aztec_content:   Base64.encode64("https://xkcd.com/#{rand(1..2000)}/")
+            },
+            GT:       {
+              rendered_ticket: Base64.encode64("https://xkcd.com/#{rand(1..2000)}/"),
+              ticket_data:     {
+                ticket_id:    '800001',
+                ticket_type:  'Ticket',
+                product_name: 'Group Ticket',
+                price:        '7.5',
+                vat_rate:     '7',
+                currency:     'EUR'
+              },
+              aztec_content:   Base64.encode64("https://xkcd.com/#{rand(1..2000)}/")
+            }
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/tickeos_b2b/test_run/order.rb
+++ b/lib/tickeos_b2b/test_run/order.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module TickeosB2b
+  module TestRun
+    class Order
+      def self.order(options, reference_id)
+        options = options.dig(:order, reference_id.to_sym)
+        ticket_data = options.dig(:ticket_data)
+
+        Nori.new.parse(
+          Nokogiri::XML::Builder.new do |xml|
+            xml.TICKeosProxy() do
+              xml.txOrderResponse do
+                xml.renderedTicket(options[:rendered_ticket])
+                xml.ticketData do
+                  xml.ticket_id(ticket_data[:ticket_id])
+                  xml.ticket_type(ticket_data[:ticket_type])
+                  xml.product_name(ticket_data[:product_name])
+                  xml.price(ticket_data[:price])
+                  xml.vat_rate(ticket_data[:vat_rate])
+                  xml.currency(ticket_data[:currency])
+                end
+                xml.aztecContent(options[:aztec_content])
+              end
+            end
+          end.to_xml
+        )
+      end
+    end
+  end
+end

--- a/lib/tickeos_b2b/test_run/product_data.rb
+++ b/lib/tickeos_b2b/test_run/product_data.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module TickeosB2b
+  module TestRun
+    class ProductData
+      def self.load!(options, reference_id)
+        options = options.dig(:product_data, reference_id.to_sym)
+
+        return Error if options.nil?
+
+        Nori.new.parse(
+          Nokogiri::XML::Builder.new do |xml|
+            xml.TICKeosProxy(apiVersion: '1.0', version: Time.now.strftime('%Y-%m-%d'), instanceName: 'test') do
+              xml.txProductDataResponse(productReferenceId: '', timeIntervalOptionType: 'type') do
+                xml.Product(
+                  id:                         options[:id],
+                  vu_name:                    options[:vu_name],
+                  vu_role:                    options[:vu_role],
+                  sort_order:                 options[:sort_order],
+                  tariff_zone_count:          options[:tariff_zone_count],
+                  tariff_zone_count_required: options[:tariff_zone_count_required],
+                  sale_date_from:             options[:sale_date_from],
+                  sale_date_to:               options[:sale_date_to],
+                  distribution_method:        options[:distribution_method],
+                  visible:                    options[:visible]
+                )
+              end
+            end
+          end.to_xml
+        )
+      end
+    end
+  end
+end

--- a/lib/tickeos_b2b/test_run/product_list.rb
+++ b/lib/tickeos_b2b/test_run/product_list.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module TickeosB2b
+  module TestRun
+    class ProductList
+      def self.product_list(options = {})
+        options = options.transform_keys(&:to_sym).dig(:product_list)
+
+        Nori.new.parse(
+          Nokogiri::XML::Builder.new do |xml|
+            xml.TICKeosProxy(apiVersion: '1.0', version: Time.now.strftime('%Y-%m-%d'), instanceName: 'test') do
+              xml.txProductResponse(method: 'product_list') do
+                options.each do |opt|
+                  opt = opt.transform_keys(&:to_sym)
+                  xml.productItem(
+                    name:         opt[:name],
+                    reference_id: opt[:reference_id],
+                    updated_at:   '1354181759',
+                    published:    '1'
+                  )
+                end
+              end
+            end
+          end.to_xml
+        )
+      end
+    end
+  end
+end

--- a/lib/tickeos_b2b/test_run/purchase.rb
+++ b/lib/tickeos_b2b/test_run/purchase.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module TickeosB2b
+  module TestRun
+    class Purchase
+      def self.purchase(options, reference_id)
+        options = options.dig(:purchase, reference_id.to_sym)
+
+        Nori.new.parse(
+          Nokogiri::XML::Builder.new do |xml|
+            xml.TICKeosProxy(apiVersion: '1.0', version: Time.now.strftime('%Y-%m-%d'), instanceName: 'test') do
+              xml.txPurchaseResponse do
+                xml.ordering(server_ordering_serial: options[:server_ordering_serial])
+                xml.productData(
+                  server_order_product_serial: options[:server_order_product_serial],
+                  price_net:                   options[:price_net],
+                  price_gross:                 options[:price_gross],
+                  price_vat:                   options[:price_vat],
+                  price_vat_rate:              options[:price_vat_rate]
+                )
+              end
+            end
+          end.to_xml
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
With this PR a test_run feature will be added to the tickeos_b2b gem. Setting the test_run parameter when initializing the Client class to true will produce mock responses for each method of the Client class. Which means no connection to the eos.uptrade API is required.