### PR TITLE
Refine `TickeosB2b::Client` class

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -12,4 +12,19 @@ require 'awesome_print'
 # Pry.start
 
 require 'irb'
+
+def reload!(print = true)
+  puts 'Reloading ...' if print
+  # Main project directory.
+  root_dir = File.expand_path('..', __dir__)
+  # Directories within the project that should be reloaded.
+  reload_dirs = %w{lib}
+  # Loop through and reload every file in all relevant project directories.
+  reload_dirs.each do |dir|
+    Dir.glob("#{root_dir}/#{dir}/**/*.rb").each { |f| load(f) }
+  end
+  # Return true when complete.
+  true
+end
+
 IRB.start(__FILE__)

--- a/lib/tickeos_b2b/client.rb
+++ b/lib/tickeos_b2b/client.rb
@@ -23,6 +23,7 @@ module TickeosB2b
                 :password,
                 :request_body,
                 :request_method,
+                :response_body,
                 :test_run,
                 :options
 
@@ -38,32 +39,23 @@ module TickeosB2b
       @request_body = Api::ProductList.request_body
       @request_method = Api::ProductList.request_method
 
-      case test_run
-      when true
-        Product.from_json(response: TestRun::ProductList.product_list(options))
-      when false
-        Product.from_json(response: call)
-      end
+      response = test_run ? TestRun::ProductList.product_list(options) : process_request
+
+      Product.from_json(response: response)
     end
 
     def load!(product:, full_product_info: false)
       @request_body = Api::ProductData.request_body(reference_id: product.reference_id)
       @request_method = Api::ProductData.request_method
 
-      return call if full_product_info & !test_run
+      return process_request if full_product_info & !test_run
 
-      case test_run
-      when true
-        Product.load_product_data(
-          product:  product,
-          response: TestRun::ProductData.load!(options, product.reference_id)
-        )
-      when false
-        Product.load_product_data(
-          product:  product,
-          response: call
-        )
-      end
+      response = test_run ? TestRun::ProductData.load!(options, product.reference_id) : process_request
+
+      Product.load_product_data(
+        product:  product,
+        response: response
+      )
     end
 
     def purchase(product:, personalisation_data:, dry_run: false)
@@ -71,24 +63,19 @@ module TickeosB2b
       raise Error::PersonalisationDataNotFound if personalisation_data.blank?
 
       ticket = product.personalize(personalisation_data)
-      pre_check = pre_check_settings(dry_run)[:pre_check]
-      go = pre_check_settings(dry_run)[:go]
+
+      pre_check = dry_run ? '1' : '0'
+      go = dry_run ? '0' : '1'
 
       @request_body = Api::Purchase.request_body(pre_check: pre_check, go: go, ticket: ticket)
       @request_method = Api::Purchase.request_method
 
-      case test_run
-      when true
-        Ticket.load_ticket_data(
-          ticket:   ticket,
-          response: TestRun::Purchase.purchase(options, product.reference_id)
-        )
-      when false
-        Ticket.load_ticket_data(
-          ticket:   ticket,
-          response: call
-        )
-      end
+      response = test_run ? TestRun::Purchase.purchase(options, product.reference_id) : process_request
+
+      Ticket.load_ticket_data(
+        ticket:   ticket,
+        response: response
+      )
     end
 
     def order(ticket:)
@@ -100,12 +87,9 @@ module TickeosB2b
       )
       @request_method = Api::Order.request_method
 
-      case test_run
-      when true
-        Order.from_json(response: TestRun::Order.order(options, ticket.product.reference_id))
-      when false
-        Order.from_json(response: call)
-      end
+      response = test_run ? TestRun::Order.order(options, ticket.product.reference_id) : process_request
+
+      Order.from_json(response: response)
     end
 
     def cancel(ticket_id:)
@@ -114,16 +98,16 @@ module TickeosB2b
       )
       @request_method = Api::Cancel.request_method
 
-      result = call
-      return :error unless result.dig('TICKeosProxy', 'txCancelResponse', 'error').blank?
+      result = process_request
+      return :error if result.dig('TICKeosProxy', 'txCancelResponse', 'error').present?
 
       :cancelled
     end
 
     private
 
-    def call
-      response = process_request
+    def process_request
+      response = send_request
       response_status = response.status.to_s
 
       unless response_status.start_with?('2')
@@ -133,8 +117,8 @@ module TickeosB2b
         raise Error::UnexpectedResponseCode, error_message_from_response(response)
       end
 
-      parsed_response = Nori.new.parse(response.body)
-      parsed_response
+      @response_body = response.body
+      Nori.new.parse(@response_body)
     end
 
     def connection
@@ -147,22 +131,22 @@ module TickeosB2b
       end
     end
 
-    def process_request
+    def send_request
       if request_method == :get
-        process_get_request
+        send_get_request
       elsif request_method == :post
-        process_post_request
+        send_post_request
       end
     end
 
-    def process_post_request
+    def send_post_request
       connection.post do |request|
         request.headers['Content-Type'] = 'application/xml'
         request.body = request_body
       end
     end
 
-    def process_get_request
+    def send_get_request
       connection.get do |request|
         request.headers['Content-Type'] = 'application/xml'
         request.body = request_body
@@ -171,12 +155,6 @@ module TickeosB2b
 
     def error_message_from_response(response)
       "#{response.status} >> #{response.body}"
-    end
-
-    def pre_check_settings(dry_run)
-      return { pre_check: '1', go: '0' } if dry_run
-
-      { pre_check: '0', go: '1' }
     end
   end
 end

--- a/lib/tickeos_b2b/client.rb
+++ b/lib/tickeos_b2b/client.rb
@@ -98,8 +98,8 @@ module TickeosB2b
       )
       @request_method = Api::Cancel.request_method
 
-      result = process_request
-      return :error if result.dig('TICKeosProxy', 'txCancelResponse', 'error').present?
+      response = process_request
+      return :error if response.dig('TICKeosProxy', 'txCancelResponse', 'error').present?
 
       :cancelled
     end


### PR DESCRIPTION
Closes #10 

This PR removes and refactors some parts of the `Client` class. This also adds the instance variable `response_body`. This means for each of the following methods (`product_list`, `load!`, `purchase`,` order`, `cancel`) the corresponding raw `request_body` and `response_body` can be retrieved.

No breaking changes!