### PR TITLE
Last Request and Response

### DIFF
--- a/lib/tickeos_b2b.rb
+++ b/lib/tickeos_b2b.rb
@@ -2,6 +2,8 @@
 
 require_relative 'tickeos_b2b/client'
 require_relative 'tickeos_b2b/error'
+require_relative 'tickeos_b2b/last_request'
+require_relative 'tickeos_b2b/last_response'
 require_relative 'tickeos_b2b/product'
 require_relative 'tickeos_b2b/ticket'
 require_relative 'tickeos_b2b/order'

--- a/lib/tickeos_b2b/last_request.rb
+++ b/lib/tickeos_b2b/last_request.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module TickeosB2b
+  class LastRequest
+    attr_reader :headers,
+                :body,
+                :options,
+                :method
+
+    def initialize(headers:, body:, options:, method:)
+      @headers = headers
+      @body = body
+      @options = options
+      @method = method
+    end
+
+    def attributes
+      {
+        headers: headers,
+        body:    body,
+        options: options,
+        method:  method
+      }
+    end
+  end
+end

--- a/lib/tickeos_b2b/last_response.rb
+++ b/lib/tickeos_b2b/last_response.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module TickeosB2b
+  class LastResponse
+    attr_reader :status,
+                :headers,
+                :body
+
+    def initialize(status:, headers:, body:)
+      @status = status
+      @headers = headers
+      @body = body
+    end
+
+    def attributes
+      {
+        status:  status,
+        headers: headers,
+        body:    body 
+      }
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces the `TickeosB2b::LastRequest` and `TickeosB2b::LastResponse` classes. These classes can be used to catch the last request to eos.uptrade and the corresponding response from eos.uptrade. This can be useful for debugging.