### PR TITLE
Fix Support for Zones

### DIFF
--- a/lib/tickeos_b2b/api/purchase.rb
+++ b/lib/tickeos_b2b/api/purchase.rb
@@ -3,7 +3,7 @@
 module TickeosB2b
   module Api
     class Purchase
-      def self.request_body(pre_check:, go:, ticket:)
+      def self.request_body(pre_check:, go:, ticket:, requires_zones:)
         Nokogiri::XML::Builder.new do |xml|
           xml.TICKeosProxy(apiVersion: '', version: '', instanceName: '') do
             xml.txPurchaseRequest(preCheck: pre_check, go: go) do
@@ -32,8 +32,10 @@ module TickeosB2b
                 xml.validationDate(timestamp: validation_date(ticket.validation_date))
                 xml.validationEndDate(timestamp: '')
                 xml.location(id: ticket.location_id)
-                xml.zone(value: ticket.start_zone || '')
-                xml.zone(value: ticket.end_zone || '')
+                if requires_zones
+                  xml.zone(value: ticket.start_zone || '')
+                  xml.zone(value: ticket.end_zone || '')
+                end
                 xml.personalisation(role: 'first_name', type: 'plain') do
                   xml.value(ticket.first_name)
                 end

--- a/lib/tickeos_b2b/client.rb
+++ b/lib/tickeos_b2b/client.rb
@@ -60,7 +60,7 @@ module TickeosB2b
       )
     end
 
-    def purchase(product:, personalisation_data:, dry_run: false)
+    def purchase(product:, personalisation_data:, requires_zones: false, dry_run: false)
       raise Error::ProductNotFound if product.blank?
       raise Error::PersonalisationDataNotFound if personalisation_data.blank?
 
@@ -69,7 +69,12 @@ module TickeosB2b
       pre_check = dry_run ? '1' : '0'
       go = dry_run ? '0' : '1'
 
-      @request_body = Api::Purchase.request_body(pre_check: pre_check, go: go, ticket: ticket)
+      @request_body = Api::Purchase.request_body(
+        pre_check:      pre_check,
+        go:             go,
+        ticket:         ticket,
+        requires_zones: requires_zones
+      )
       @request_method = Api::Purchase.request_method
 
       response = test_run ? TestRun::Purchase.purchase(options, product.reference_id) : process_request

--- a/spec/tickeos_b2b/api/purchase_spec.rb
+++ b/spec/tickeos_b2b/api/purchase_spec.rb
@@ -41,9 +41,10 @@ RSpec.describe TickeosB2b::Api::Purchase do
 
   let(:operation) do
     purchase.request_body(
-      pre_check: pre_check,
-      go:        go,
-      ticket:    ticket
+      pre_check:      pre_check,
+      go:             go,
+      ticket:         ticket,
+      requires_zones: true
     )
   end
   let(:pre_check) { '0' }


### PR DESCRIPTION
Zones should not be used when a ticket product does not require them. Otherwise, the purchase request will fail and will return a `purchase_error 0300`. This PR adds a `requires_zones` flag that can be set to true when a ticket product requires zones. Default value for this flag is false.

Usage:

```ruby
ticket = ticket_client.purchase(
  product: product,
  personalisation_data: personalization_data,
  requires_zones: true,
  dry_run: false
)
```