### PR TITLE
Support `ticket_reference` in Order Request

### DIFF
--- a/lib/tickeos_b2b/api/order.rb
+++ b/lib/tickeos_b2b/api/order.rb
@@ -3,14 +3,14 @@
 module TickeosB2b
   module Api
     class Order
-      def self.request_body(server_ordering_serial:, server_order_product_serial:)
+      def self.request_body(server_ordering_serial:, server_order_product_serial:, part:)
         Nokogiri::XML::Builder.new do |xml|
           xml.TICKeosProxy(apiVersion: '', version: '', instanceName: '') do
             xml.txOrderRequest(
               orderingSerial:     server_ordering_serial,
               orderProductSerial: server_order_product_serial
             ) do
-              xml.part('ticket')
+              xml.part(part)
               xml.ticketParameter(app: 'mobile', outputFormat: 'png')
             end
           end

--- a/lib/tickeos_b2b/client.rb
+++ b/lib/tickeos_b2b/client.rb
@@ -85,12 +85,13 @@ module TickeosB2b
       )
     end
 
-    def order(ticket:)
+    def order(ticket:, part: 'ticket')
       raise Error::TicketNotFound if ticket.blank?
 
       @request_body = Api::Order.request_body(
         server_ordering_serial:      ticket.server_ordering_serial,
-        server_order_product_serial: ticket.server_order_product_serial
+        server_order_product_serial: ticket.server_order_product_serial,
+        part:                        part
       )
       @request_method = Api::Order.request_method
 

--- a/lib/tickeos_b2b/order.rb
+++ b/lib/tickeos_b2b/order.rb
@@ -7,7 +7,8 @@ module TickeosB2b
       :state,
       :rendered_ticket,
       :ticket_data,
-      :aztec_content
+      :aztec_content,
+      :ordering
     ].freeze
 
     attr_accessor(*ATTRIBUTES)
@@ -32,7 +33,8 @@ module TickeosB2b
         state:           :valid,
         rendered_ticket: response.dig('renderedTicket'),
         ticket_data:     response.dig('ticketData'),
-        aztec_content:   response.dig('aztecContent')
+        aztec_content:   response.dig('aztecContent'),
+        ordering:        response.dig('ordering')
       )
     end
   end

--- a/spec/tickeos_b2b/api/order_spec.rb
+++ b/spec/tickeos_b2b/api/order_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe TickeosB2b::Api::Order do
   let(:operation) do
     order.request_body(
       server_ordering_serial:      server_ordering_serial,
-      server_order_product_serial: server_order_product_serial
+      server_order_product_serial: server_order_product_serial,
+      part:                        'ticket'
     )
   end
   let(:server_ordering_serial) { '42' }

--- a/spec/tickeos_b2b/order_spec.rb
+++ b/spec/tickeos_b2b/order_spec.rb
@@ -70,7 +70,8 @@ RSpec.describe TickeosB2b::Order do
         state:           nil,
         rendered_ticket: nil,
         ticket_data:     nil,
-        aztec_content:   nil
+        aztec_content:   nil,
+        ordering:        nil
       }
     end
 
@@ -87,6 +88,7 @@ RSpec.describe TickeosB2b::Order do
     let(:rendered_ticket) { expected_order_response['TICKeosProxy']['txOrderResponse']['renderedTicket'] }
     let(:ticket_data) { expected_order_response['TICKeosProxy']['txOrderResponse']['ticketData'] }
     let(:aztec_content) { expected_order_response['TICKeosProxy']['txOrderResponse']['aztecContent'] }
+    let(:ordering) { expected_order_response['TICKeosProxy']['txOrderResponse']['ordering'] }
 
     it 'extracts the information from order hash correctly' do
       order
@@ -95,6 +97,7 @@ RSpec.describe TickeosB2b::Order do
       expect(order.rendered_ticket).to eq(rendered_ticket)
       expect(order.ticket_data).to eq(ticket_data)
       expect(order.aztec_content).to eq(aztec_content)
+      expect(order.ordering).to eq(ordering)
     end
   end
 end


### PR DESCRIPTION
This PR adds the option to choose between `ticket` or `ticket_reference` in the order request.
- `ticket` will return the full `ticket_data` and the `rendered_ticket` (as png)
- `ticket_reference` will return the `ticket_data` and the `customer_code`

The `customer_code` is needed when a ticket should be retrieved via mobile SDK.

Usage:

```ruby
order = ticket_client.order(ticket: ticket, part: 'ticket_reference')
```
or 
```ruby
order = ticket_client.order(ticket: ticket, part: 'ticket')
```