### PR TITLE
fix: remove time from validation_date

### DIFF
--- a/lib/tickeos_b2b/api/purchase.rb
+++ b/lib/tickeos_b2b/api/purchase.rb
@@ -66,7 +66,7 @@ module TickeosB2b
         return '' if datetime.blank?
         return datetime if datetime.is_a?(String)
 
-        datetime.strftime('%FT%T%:z')
+        datetime.to_date.to_s
       end
 
       def self.request_method

--- a/spec/tickeos_b2b/api/purchase_spec.rb
+++ b/spec/tickeos_b2b/api/purchase_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TickeosB2b::Api::Purchase do
             <identityCard ref_id="p" name="Personalausweis" value="" number=""/>
           </orderCustomer>
           <optionProduct reference_id="test_ticket" quantity="1" serial_number="42">
-            <validationDate timestamp="2020-09-02T00:00:00+00:00"/>
+            <validationDate timestamp="2020-09-02"/>
             <validationEndDate timestamp=""/>
             <location id="Master:8123456"/>
             <zone value=""/>


### PR DESCRIPTION
In order to display the validity date of a ticket correctly (see attached screenshots), the `validation_date` that is passed to the tickeos api needs to be a date not a timestamp. This PR will take care of this.

Incorrect version:
![Screenshot 2023-01-04 at 12 05 48](https://user-images.githubusercontent.com/64846810/210542037-92757bfa-69a5-4e51-96d0-956817b2629a.png)

Correct version:
![Screenshot 2023-01-04 at 12 05 32](https://user-images.githubusercontent.com/64846810/210542048-584715a6-3c21-47a0-af69-9921e03b5059.png)
