### PR TITLE
fix: remove useless check in purchase endpoint

### DIFF
--- a/lib/tickeos_b2b/api/purchase.rb
+++ b/lib/tickeos_b2b/api/purchase.rb
@@ -64,7 +64,6 @@ module TickeosB2b
 
       def self.validation_date(datetime)
         return '' if datetime.blank?
-        return datetime if datetime.is_a?(String)
 
         datetime.to_date.to_s
       end


### PR DESCRIPTION
As the title suggests, this PR just removes a useless check.